### PR TITLE
Removing spaces as separators, they make no sense and can be dangerous

### DIFF
--- a/iso4217.yml
+++ b/iso4217.yml
@@ -84,7 +84,7 @@ KHR:
   symbol: ៛
 PLN:
   separators:
-    major: ' '
+    major: '.'
     minor: ','
   minor_unit: 2
   currency: Zloty
@@ -390,7 +390,7 @@ PYG:
   symbol: Gs
 LBP:
   separators:
-    major: ' '
+    major: ','
     minor: '.'
   minor_unit: 2
   currency: Lebanese Pound
@@ -601,7 +601,7 @@ HUF:
   symbol: Ft
 LTL:
   separators:
-    major: ' '
+    major: '.'
     minor: ','
   minor_unit: 2
   currency: Lithuanian Litas
@@ -695,7 +695,7 @@ PHP:
   symbol: ₱
 ZAR:
   separators:
-    major: ' '
+    major: ','
     minor: '.'
   minor_unit: 2
   currency: Rand
@@ -725,7 +725,7 @@ TMT:
   symbol: 
 UAH:
   separators:
-    major: ' '
+    major: '.'
     minor: ','
   minor_unit: 2
   currency: Hryvnia
@@ -779,7 +779,7 @@ MKD:
   symbol: ден
 AUD:
   separators:
-    major: ' '
+    major: ','
     minor: '.'
   minor_unit: 2
   currency: Australian Dollar


### PR DESCRIPTION
There was only one major currency with a space separator - AUD. This would mean that numbers would be formatted like "$1 245.20", if we followed what the specification says, according to this YML file.

However, I wasn't able to find the ISO 4217 specification which dictated the major and minor separators for each currency. This means that I suspect that it isn't in fact part of this spec, and perhaps the reason behind specifying major and minor unit notation in this YML file is for convenience only. See https://www.currency-iso.org/dam/downloads/lists/list_one.xml for the official ISO 4217 spec.

It's also worth nothing that in total, exactly 6 currency codes had a space as their major separator - 3 with a `minor: '.'` (i.e. US / UK style) and 3 with `minor: ','` (i.e. European style). These numbers are oddly low compared to the alternatives. Perhaps this whole thing is an error.

So - let's get rid of the outliers. If there is a minor unit of `,`, then your major unit will be `.` as per European style. Likewise, if you have a minor unit of `.`, then your major unit will be `,`.